### PR TITLE
Associated lists are deleted when a user account is deleted

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ActiveRecord::Base
   validates :password, length: {within: Devise.password_length, allow_blank: true}
   validates :role, presence: true
 
-  has_many :lists
+  has_many :lists, dependent: :destroy
 
   def to_s
     email

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -5,5 +5,14 @@ RSpec.describe List do
   describe '@name' do
     it { should validate_presence_of(:name) }
   end
-  
+
+  describe "@santas" do
+    let!(:list) { FactoryGirl.create(:list) }
+    let!(:santa) { FactoryGirl.create(:santa, list_id: list.id) }
+
+    it "deletes associated lists if the user account is deleted" do
+      expect { list.destroy }.to change { Santa.count }.by(-1)
+    end
+  end
+
 end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe List do
     let!(:list) { FactoryGirl.create(:list) }
     let!(:santa) { FactoryGirl.create(:santa, list_id: list.id) }
 
-    it "deletes associated lists if the user account is deleted" do
+    it "deletes associated santas if the list is deleted" do
       expect { list.destroy }.to change { Santa.count }.by(-1)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe User do
     end
   end
 
+  describe "@lists" do
+    let!(:user) { FactoryGirl.create(:user) }
+    let!(:santa_list) { FactoryGirl.create(:list, user_id: user.id) }
+
+    it "deletes associated lists if the user account is deleted" do
+      expect { user.destroy }.to change { List.count }.by(-1)
+    end
+  end
+
   describe '@password' do
     it { should validate_presence_of(:password) }
   end


### PR DESCRIPTION
Adds `dependent: :destroy` to user model for lists, updates associated tests